### PR TITLE
Add edit functionality for person's phone number

### DIFF
--- a/src/seedu/addressbook/commands/Command.java
+++ b/src/seedu/addressbook/commands/Command.java
@@ -2,6 +2,7 @@ package seedu.addressbook.commands;
 
 import seedu.addressbook.common.Messages;
 import seedu.addressbook.data.AddressBook;
+import seedu.addressbook.data.person.Person;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 
 import java.util.List;
@@ -56,6 +57,10 @@ public abstract class Command {
      */
     protected ReadOnlyPerson getTargetPerson() throws IndexOutOfBoundsException {
         return relevantPersons.get(getTargetIndex() - DISPLAYED_INDEX_OFFSET);
+    }
+    
+    protected Person getEditablePerson() throws IndexOutOfBoundsException {
+    	return (Person) relevantPersons.get(getTargetIndex() - DISPLAYED_INDEX_OFFSET);
     }
 
     public int getTargetIndex() {

--- a/src/seedu/addressbook/commands/Command.java
+++ b/src/seedu/addressbook/commands/Command.java
@@ -4,6 +4,7 @@ import seedu.addressbook.common.Messages;
 import seedu.addressbook.data.AddressBook;
 import seedu.addressbook.data.person.Person;
 import seedu.addressbook.data.person.ReadOnlyPerson;
+import seedu.addressbook.data.person.ReadWritePerson;
 
 import java.util.List;
 
@@ -59,7 +60,7 @@ public abstract class Command {
         return relevantPersons.get(getTargetIndex() - DISPLAYED_INDEX_OFFSET);
     }
     
-    protected Person getEditablePerson() throws IndexOutOfBoundsException {
+    protected ReadWritePerson getEditablePerson() throws IndexOutOfBoundsException {
     	return (Person) relevantPersons.get(getTargetIndex() - DISPLAYED_INDEX_OFFSET);
     }
 

--- a/src/seedu/addressbook/commands/EditCommand.java
+++ b/src/seedu/addressbook/commands/EditCommand.java
@@ -20,7 +20,7 @@ public class EditCommand extends Command {
             + "\n\t"
             + "Parameters: INDEX p/NEW_NUMBER\n\t"
             + "Example: " + COMMAND_WORD
-            + " John Doe p/98765432";
+            + " 1 p/999";
 
     public static final String MESSAGE_SUCCESS = "%1$s edited.";
     

--- a/src/seedu/addressbook/commands/EditCommand.java
+++ b/src/seedu/addressbook/commands/EditCommand.java
@@ -1,0 +1,51 @@
+package seedu.addressbook.commands;
+
+import seedu.addressbook.common.Messages;
+import seedu.addressbook.data.exception.IllegalValueException;
+import seedu.addressbook.data.person.*;
+import seedu.addressbook.data.tag.Tag;
+import seedu.addressbook.data.tag.UniqueTagList;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Adds a person to the address book.
+ */
+public class EditCommand extends Command {
+
+    public static final String COMMAND_WORD = "edit";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ":\n" + "Edits a person's phone number (by index) in the address book. "
+            + "\n\t"
+            + "Parameters: INDEX p/NEW_NUMBER\n\t"
+            + "Example: " + COMMAND_WORD
+            + " John Doe p/98765432";
+
+    public static final String MESSAGE_SUCCESS = "%1$s edited.";
+    
+    private final Phone newPhone;
+
+    /**
+     * Convenience constructor using raw values.
+     * @throws IllegalValueException 
+     */
+    public EditCommand(int targetVisibleIndex, String newPhone, boolean isPhonePrivate) throws IllegalValueException {
+    	super(targetVisibleIndex);
+    	this.newPhone = new Phone(newPhone, isPhonePrivate);
+    }
+    
+    @Override
+    public CommandResult execute() {
+        try {
+            final Person target = getEditablePerson();
+            if (!addressBook.containsPerson(target)) {
+                return new CommandResult(Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK);
+            }
+            target.editPhone(newPhone);
+            return new CommandResult(String.format(MESSAGE_SUCCESS, target.getName()));
+        } catch (IndexOutOfBoundsException ie) {
+            return new CommandResult(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+    }
+}

--- a/src/seedu/addressbook/commands/EditCommand.java
+++ b/src/seedu/addressbook/commands/EditCommand.java
@@ -38,7 +38,7 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute() {
         try {
-            final Person target = getEditablePerson();
+            final ReadWritePerson target = getEditablePerson();
             if (!addressBook.containsPerson(target)) {
                 return new CommandResult(Messages.MESSAGE_PERSON_NOT_IN_ADDRESSBOOK);
             }

--- a/src/seedu/addressbook/commands/HelpCommand.java
+++ b/src/seedu/addressbook/commands/HelpCommand.java
@@ -13,6 +13,7 @@ public class HelpCommand extends Command {
 
     public static final String MESSAGE_ALL_USAGES = AddCommand.MESSAGE_USAGE
             + "\n" + DeleteCommand.MESSAGE_USAGE
+            + "\n" + EditCommand.MESSAGE_USAGE
             + "\n" + ClearCommand.MESSAGE_USAGE
             + "\n" + FindCommand.MESSAGE_USAGE
             + "\n" + ListCommand.MESSAGE_USAGE

--- a/src/seedu/addressbook/data/person/Person.java
+++ b/src/seedu/addressbook/data/person/Person.java
@@ -8,7 +8,7 @@ import java.util.Objects;
  * Represents a Person in the address book.
  * Guarantees: details are present and not null, field values are validated.
  */
-public class Person implements ReadOnlyPerson {
+public class Person implements ReadOnlyPerson, ReadWritePerson {
 
     private Name name;
     private Phone phone;
@@ -63,6 +63,7 @@ public class Person implements ReadOnlyPerson {
      * Replaces this person's phone number with the given new phone number.
      * @param newPhone
      */
+    @Override
     public void editPhone(Phone newPhone) {
     	this.phone = newPhone;
     }

--- a/src/seedu/addressbook/data/person/Person.java
+++ b/src/seedu/addressbook/data/person/Person.java
@@ -58,6 +58,14 @@ public class Person implements ReadOnlyPerson {
     public UniqueTagList getTags() {
         return new UniqueTagList(tags);
     }
+    
+    /**
+     * Replaces this person's phone number with the given new phone number.
+     * @param newPhone
+     */
+    public void editPhone(Phone newPhone) {
+    	this.phone = newPhone;
+    }
 
     /**
      * Replaces this person's tags with the tags in the argument tag list.

--- a/src/seedu/addressbook/data/person/ReadWritePerson.java
+++ b/src/seedu/addressbook/data/person/ReadWritePerson.java
@@ -1,0 +1,5 @@
+package seedu.addressbook.data.person;
+
+public interface ReadWritePerson extends ReadOnlyPerson {
+    void editPhone(Phone newPhone);
+}

--- a/src/seedu/addressbook/parser/Parser.java
+++ b/src/seedu/addressbook/parser/Parser.java
@@ -65,6 +65,9 @@ public class Parser {
             case DeleteCommand.COMMAND_WORD:
                 return prepareDelete(arguments);
 
+            case EditCommand.COMMAND_WORD:
+            	return prepareEdit(arguments);
+                
             case ClearCommand.COMMAND_WORD:
                 return new ClearCommand();
 
@@ -156,6 +159,27 @@ public class Parser {
         } catch (ParseException | NumberFormatException e) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
+    }
+    
+    /**
+     * Parses arguments in the context of the edit command.
+     *
+     * @param args full command args string
+     * @return the prepared command
+     */
+    private Command prepareEdit(String args) {
+
+    	// Split args into index and input phone number
+    	String[] argsArray = args.split(" p/");
+    	try {
+    		final int targetIndex = parseArgsAsDisplayedIndex(argsArray[0]);
+    		final String targetNewPhone = argsArray[1];
+    		return new EditCommand(targetIndex, targetNewPhone, false);
+    	} catch (ParseException | NumberFormatException | ArrayIndexOutOfBoundsException e) {
+    		return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+    	} catch (IllegalValueException ive) {
+    		return new IncorrectCommand(ive.getMessage());
+    	}
     }
 
     /**


### PR DESCRIPTION
Using the `edit` command, a person's phone number may be changed by the user.

**Command Format**
`edit INDEX p/NEW_NUMBER`

where _INDEX_ is an int representing the current index the person is stored at, and _NEW_NUMBER_ is a string of a new phone number, which is validated by the default parser.

The default privacy of the new phone number is set to public.
